### PR TITLE
Add multiple transitions per event

### DIFF
--- a/spec/aasm/event_spec.cr
+++ b/spec/aasm/event_spec.cr
@@ -8,8 +8,8 @@ module AASM
       end
 
       it "accepts Transition" do
-        e = Event.new Transition.new({from: :pending, to: :active})
-        e.transition.should_not be_nil
+        e = Event.new [Transition.new({from: :pending, to: :active})]
+        e.transition.should_not be_empty
       end
     end
 
@@ -17,14 +17,18 @@ module AASM
       it "creates new transition" do
         e = Event.new
         e.transitions(from: :pending, to: :active)
-        e.transition.should_not be_nil
+        e.transition.should_not be_empty
       end
 
-      it "does not create new transition if it been created" do
+      it "adds more transitions" do
         e = Event.new
         e.transitions(from: :pending, to: :active)
         e.transitions(from: :active, to: :competed)
-        e.transition.from.should eq [:pending]
+        e.transition.first.from.should eq [:pending]
+        e.transition.first.to.should eq :active
+        e.transition.last.from.should eq [:active]
+        e.transition.last.to.should eq :competed
+        e.transition.size.should eq(2)
       end
     end
 

--- a/spec/aasm/exceptions_spec.cr
+++ b/spec/aasm/exceptions_spec.cr
@@ -25,9 +25,9 @@ module AASM
     end
   end
 
-  describe UnableToChangeState do
+  describe UnableToChangeStateException do
     it "raises" do
-      expect_raises(AASMException) { raise UnableToChangeState.new :pending, :active }
+      expect_raises(AASMException) { raise UnableToChangeStateException.new :pending }
     end
   end
 end

--- a/spec/aasm/state_machine_spec.cr
+++ b/spec/aasm/state_machine_spec.cr
@@ -202,7 +202,7 @@ module AASM
         s.state :active
         s.state :completed
         s.event :complete { |e| e.transitions from: :active, to: :completed }
-        expect_raises(UnableToChangeState) { s.fire_event :complete, true }
+        expect_raises(UnableToChangeStateException) { s.fire_event :complete, true }
       end
     end
   end

--- a/src/aasm/event.cr
+++ b/src/aasm/event.cr
@@ -2,11 +2,11 @@ class AASM::Event
   getter! :transition
   getter :before, :after
 
-  def initialize(@transition : Transition? = nil)
+  def initialize(@transition : Array(Transition) = Array(Transition).new)
   end
 
   def transitions(from : (Symbol | Array(Symbol)) = nil, to : Symbol = nil)
-    @transition ||= Transition.new({from: from, to: to})
+    @transition << Transition.new({from: from, to: to})
   end
 
   def before(&block)

--- a/src/aasm/exceptions.cr
+++ b/src/aasm/exceptions.cr
@@ -26,9 +26,15 @@ module AASM
     end
   end
 
-  class UnableToChangeState < AASMException
-    def initialize(from, to)
-      super "Unable to change state from '#{from}' to '#{to}'"
+  class UnableToChangeStateException < AASMException
+    def initialize(from)
+      super "Unable to change state from '#{from}'"
+    end
+  end
+
+  class NoTransitionsException < AASMException
+    def initialize
+      super "Unable to fire event with empty transitions"
     end
   end
 end


### PR DESCRIPTION
**Support multiple transitions per event.**

Clear examples are in Ruby's AASM gem:

<details>
<summary>Callbacks section</summary>

https://github.com/aasm/aasm#callbacks

```ruby
event :run, after: :notify_somebody do
  transitions from: :sleeping, to: :running, after: Proc.new {|*args| set_process(*args) }
  transitions from: :running, to: :finished, after: LogRunTime
end
```
</details>

Or:

<details>
<summary>Guard section</summary>

https://github.com/aasm/aasm#guards

```ruby
event :clean_if_needed do
  transitions from: :idle, to: :cleaning do
    guard do
      cleaning_needed?
    end
  end
  transitions from: :idle, to: :idle
end
```
</details>

**Why could it be viable?**

A handler which should stop on different errors by the only event depending on a current state.

<details>
<summary>Usecase</summary>

```crystal
class CliState
  include AASM

  def act_as_state_machine
    aasm.state :init, initial: true
    aasm.state :key_loaded
    aasm.state :signature_is_valid
    aasm.state :data_loaded

    aasm.state :key_loading_error
    aasm.state :signature_verification_failed
    aasm.state :data_processing_failed

    aasm.event :load_key do |event|
      event.transitions from: :init, to: :key_loaded
    end

    aasm.event :check_signature do |event|
      event.transitions from: :key_loaded, to: :signature_is_valid
    end

    aasm.event :load_data do |event|
      event.transitions from: :signature_is_valid, to: :data_loaded
    end

    # Problem is here
    aasm.event :stop_with_error do |event|
      event.transitions from: :init, to: :key_loading_error
      event.transitions from: :key_loaded, to: :signature_verification_failed
      event.transitions from: :signature_is_valid, to: :data_processing_failed
    end
  end
end

cli_state = CliState.new.tap &.act_as_state_machine

first_result = :success
cli_state.fire first_result == :success ? :load_key : :stop_with_error
p cli_state.state # => :key_loaded

second_result = :fail
cli_state.fire second_result == :success ? :check_signature : :stop_with_error
p cli_state.state # => :signature_verification_failed

cli_state.fire :load_data
p cli_state.state # => :signature_verification_failed
```

</details>

*Breaking change:* because of new transitions behaviour this PR changes `UnableToChangeStateException` message - exclude `to` field because now there could be more than one finish points.